### PR TITLE
feat: Adds Basic Twitter Auth Functionality

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -2,6 +2,7 @@ module.exports = {
   color: true,
   extension: ['ts'],
   ignore: ['node_modules'],
+  recursive: true,
   require: 'ts-node/register',
   testEnvironment: 'node',
   ui: 'bdd',

--- a/dotenv-example
+++ b/dotenv-example
@@ -1,0 +1,2 @@
+export TWITTER_CONSUMER_KEY='your-consumer-key-here'
+export TWITTER_CONSUMER_SECRET='your-consumer-secret-here'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "apollo-server-express": "^2.14.2",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "twitter-lite": "^0.13.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import { ApolloServer, gql } from 'apollo-server-express';
 
+import { getAuthTwitter, getAuthCallbackTwitter } from './routes/authRoutes';
+
 const typeDefs = gql`
   type Query {
     hello: String
@@ -15,9 +17,12 @@ const resolvers = {
 
 const gqlServer = new ApolloServer({ typeDefs, resolvers });
 
-const app = express();
+const app: express.Application = express();
 
 app.set('port', process.env.PORT || 4000);
+
+app.get('/auth/twitter', getAuthTwitter);
+app.get('/auth/callback/twitter', getAuthCallbackTwitter);
 
 gqlServer.applyMiddleware({ app });
 

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import Twitter from 'twitter-lite';
+
+// This Twitter client only contains the consumerKey and consumer secret so it
+// can only be used for API requests to initialize auth
+const authClient = new Twitter({
+  consumer_key: process.env.TWITTER_CONSUMER_KEY!,
+  consumer_secret: process.env.TWITTER_CONSUMER_SECRET!,
+});
+
+async function getAuthTwitter(_req: express.Request, res: express.Response) {
+  try {
+    // The typing for the twitter-lite library is incorrect and doesn't think
+    // the oauth_token value exists on the getRequestToken response
+    // Created https://github.com/draftbit/twitter-lite/pull/105 to resolve this
+    // typing issue in the twitter-lite library
+    // @ts-ignore TS2339
+    const { oauth_token: oauthToken } = await authClient.getRequestToken(
+      'http://localhost:4000/auth/callback/twitter',
+    );
+
+    return res.redirect(
+      `https://api.twitter.com/oauth/authenticate?oauth_token=${oauthToken}`,
+    );
+  } catch (error) {
+    const errorCode = error.errors[0].code;
+
+    res.status(errorCode);
+    return res.json(error);
+  }
+}
+
+async function getAuthCallbackTwitter(
+  req: express.Request,
+  res: express.Response,
+) {
+  try {
+    const accessInfo = await authClient.getAccessToken({
+      oauth_token: req?.query?.oauth_token as string,
+      oauth_verifier: req?.query?.oauth_verifier as string,
+    });
+
+    const {
+      oauth_token: oauthToken,
+      oauth_token_secret: oauthTokenSecret,
+      user_id: userId,
+      screen_name: screenName,
+    } = accessInfo;
+
+    res.json({
+      oauthToken,
+      oauthTokenSecret,
+      userId,
+      screenName,
+    });
+  } catch {
+    // The authClient doesn't return a useful error here, so call it a
+    // 500, but send a message that says they may not have authorized
+    // this app for Twitter
+    res.status(500);
+    res.json({
+      errors: [
+        {
+          code: 500,
+          message:
+            'Unknown error failing to retrieve request token. The user may not have authorized this app for Twitter.',
+        },
+      ],
+    });
+  }
+}
+
+export { getAuthTwitter, getAuthCallbackTwitter };

--- a/test/integration/routes/authRoutes.test.ts
+++ b/test/integration/routes/authRoutes.test.ts
@@ -1,0 +1,102 @@
+import request from 'supertest';
+import nock from 'nock';
+import { assert } from 'chai';
+import { app } from '../../../src/app';
+
+describe('test /auth routes', () => {
+  describe('test /twitter auth route', () => {
+    it('should return a redirect with a valid oauth_token on success', async () => {
+      nock('https://api.twitter.com:443')
+        .post('/oauth/request_token')
+        .query(true)
+        .reply(
+          200,
+          'oauth_token=Ujs81AAAAAAAfLM7AAABck3ZW6Y&oauth_token_secret=z3qBkNsw8LCazmu8eGOPoGzssY3hrEA0&oauth_callback_confirmed=true',
+        );
+
+      const res = await request(app).get('/auth/twitter');
+
+      assert.equal(res.status, 302);
+      assert.equal(
+        res.get('location'),
+        'https://api.twitter.com/oauth/authenticate?oauth_token=Ujs81AAAAAAAfLM7AAABck3ZW6Y',
+      );
+      assert.equal(
+        res.text,
+        'Found. Redirecting to https://api.twitter.com/oauth/authenticate?oauth_token=Ujs81AAAAAAAfLM7AAABck3ZW6Y',
+      );
+    });
+    it('should return a the twitter api response errror on a failure', async () => {
+      nock('https://api.twitter.com:443')
+        .post('/oauth/request_token')
+        .query(true)
+        .reply(403, {
+          errors: [
+            {
+              code: 415,
+              message:
+                'Callback URL not approved for this client application. Approved callback URLs can be adjusted in your application settings',
+            },
+          ],
+        });
+
+      const res = await request(app).get('/auth/twitter');
+
+      assert.equal(res.status, 415);
+      assert.equal(res.body.errors[0].code, 415);
+      assert.equal(
+        res.body.errors[0].message,
+        'Callback URL not approved for this client application. Approved callback URLs can be adjusted in your application settings',
+      );
+    });
+  });
+  describe('test /callback/twitter auth route', () => {
+    it('should return a json body with the twitter secrets and user info on success', async () => {
+      nock('https://api.twitter.com:443')
+        .post('/oauth/access_token')
+        .query(true)
+        .reply(
+          200,
+          'oauth_token=6253282-eWudHldSbIaelX7swmsiHImEL4KinwaGloHANdrY&oauth_token_secret=2EEfA6BG5ly3sR3XjE0IBSnlQu4ZrUzPiYTmrkVU&user_id=6253282&screen_name=twitterapi',
+        );
+
+      const res = await request(app)
+        .get('/auth/callback/twitter')
+        .query(
+          'oauth_token=qLBVyoAAAAAAx72QAAATZxQWU6P&oauth_verifier=ghLM8lYmAxDbaqL912RZSRjCCEXKDIzx',
+        );
+
+      assert.equal(
+        res.body.oauthToken,
+        '6253282-eWudHldSbIaelX7swmsiHImEL4KinwaGloHANdrY',
+      );
+      assert.equal(
+        res.body.oauthTokenSecret,
+        '2EEfA6BG5ly3sR3XjE0IBSnlQu4ZrUzPiYTmrkVU',
+      );
+      assert.equal(res.body.userId, '6253282');
+      assert.equal(res.body.screenName, 'twitterapi');
+    });
+    it('should return a generic 500 error on failure', async () => {
+      nock('https://api.twitter.com:443')
+        .post('/oauth/access_token')
+        .query(true)
+        .reply(401, [
+          '1f8b08000000000000000a4a2d2c4d2d2e5128c9cf4ecd53c8cd2c2ececc4b07000000ffff0300b2b3ffc815000000',
+        ]);
+
+      const res = await request(app)
+        .get('/auth/callback/twitter')
+        .query(
+          'oauth_token=qLBVyoAAAAAAx72QAAATZxQWU6P&oauth_verifier=ghLM8lYmAxDbaqL912RZSRjCCEXKDIzx',
+        );
+
+      assert.equal(res.status, 500);
+      assert.equal(res.body.errors[0].code, 500);
+      assert.equal(
+        res.body.errors[0].message,
+        'Unknown error failing to retrieve request token. The user may not have authorized this app for Twitter.',
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,14 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
+cross-fetch@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+  dependencies:
+    node-fetch "2.6.0"
+    whatwg-fetch "3.0.0"
+
 cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -2404,7 +2412,7 @@ node-environment-flags@1.0.6:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@^2.1.2, node-fetch@^2.2.0:
+node-fetch@2.6.0, node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -2451,6 +2459,11 @@ normalize-url@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+
+oauth-1.0a@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz#eadbccdb3bceea412d24586e6f39b2b412f0e491"
+  integrity sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==
 
 object-assign@^4:
   version "4.1.1"
@@ -3360,6 +3373,14 @@ tsutils@^3.17.1:
   dependencies:
     tslib "^1.8.1"
 
+twitter-lite@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/twitter-lite/-/twitter-lite-0.13.0.tgz#e92ef340faba9a45c819ec5b2489a9e76a2b8b28"
+  integrity sha512-UQxOqiZIx6BbWMNXrFhDThHf0RYuAWe02+0wHbsww61iIPeJdaakM+HJJlf8QKzIyu8q6JCZ4K9vpd55sg0V7g==
+  dependencies:
+    cross-fetch "^3.0.0"
+    oauth-1.0a "^2.2.4"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -3501,6 +3522,11 @@ vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+whatwg-fetch@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Adds basic functionality for auth with Twitter
- Currently this just allows a user to GET the /auth/twitter endpoint
  perform the 3-legged oauth flow and retrieve oauth credentials for
  that user
- In the future, the oauth credentials will be stored in this app and
  the app will return the user a bearer token they can use to auth with
  this app